### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11-jdk-slim
 ARG jar
-COPY $jar rmcensusadapter.jar
+COPY $jar /opt/rmcensusadapter.jar
 ENV JAVA_OPTS=""
-ENTRYPOINT [ "sh", "-c", "java -jar /rmcensusadapter.jar" ]
+ENTRYPOINT [ "sh", "-c", "java -jar /opt/rmcensusadapter.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:11-jdk-slim
 ARG jar
 COPY $jar /opt/rmcensusadapter.jar
 ENV JAVA_OPTS=""
-ENTRYPOINT [ "sh", "-c", "java -jar /opt/rmcensusadapter.jar" ]
+ENTRYPOINT [ "java", "-jar", "/opt/rmcensusadapter.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM openjdk:11-jdk-slim
 ARG jar
-VOLUME /tmp
 COPY $jar rmcensusadapter.jar
 ENV JAVA_OPTS=""
 ENTRYPOINT [ "sh", "-c", "java -jar /rmcensusadapter.jar" ]


### PR DESCRIPTION
Three improvements to the Docker file.

The _exec_ form of `ENTRYPOINT` should be used to ensure that there's just a Java process running rather than a shell process that launches the Java process. This also ensures that the Java process will be sent any Unix signals rather than the shell process. See https://docs.docker.com/engine/reference/builder/#entrypoint