### PR TITLE
FWMT-682 update rabbithealth endpoint to be consistent with job service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ env:
 branches:
   only:
   - master
-notifications:
-  slack: 
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/src/main/java/uk/gov/ons/fwmt/census/rmadapter/controller/RabbitHealthCheckController.java
+++ b/src/main/java/uk/gov/ons/fwmt/census/rmadapter/controller/RabbitHealthCheckController.java
@@ -8,10 +8,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 @Slf4j
+@RestController
 @RequestMapping("/rabbitHealth")
 public class RabbitHealthCheckController {
 
@@ -23,15 +29,36 @@ public class RabbitHealthCheckController {
   @Qualifier("fwmtConnectionFactory")
   private ConnectionFactory fwmtConnectionFactory;
 
-  @RequestMapping(value = "/queue", method = RequestMethod.GET, produces = "application/json")
-  public boolean canAccessQueue(@RequestParam("qname") String qname) {
-    ConnectionFactory cf = ("Action.Field".equals(qname) || "Action.FieldDLQ".equals(qname)) ?
-        rmFactory :
-        fwmtConnectionFactory;
-    RabbitAdmin rabbitAdmin = new RabbitAdmin(cf);
+  private RabbitAdmin rmRabbitAdmin;
+  private RabbitAdmin fwmtRabbitAdmin;
 
-    Properties queueProperties = rabbitAdmin.getQueueProperties(qname);
-    return (queueProperties != null && qname.equals(queueProperties.getProperty("QUEUE_NAME")));
+  private String checkQueue(String queueName) {
+    RabbitAdmin rabbitAdmin = ("Action.Field".equals(queueName) || "Action.FieldDLQ".equals(queueName)) ?
+        rmRabbitAdmin :
+        fwmtRabbitAdmin;
+    Properties props = rabbitAdmin.getQueueProperties(queueName);
+    return (props != null) ? props.getProperty("QUEUE_NAME") : null;
   }
+
+  @RequestMapping(value = "/rabbitHealth", method = RequestMethod.GET, produces = "application/json")
+  public List<String> canAccessQueue() {
+    rmRabbitAdmin = new RabbitAdmin(rmFactory);
+    fwmtRabbitAdmin = new RabbitAdmin(fwmtConnectionFactory);
+    List<String> queues = Arrays.asList(
+        "gateway.feedback",
+        "gateway.feedback.DLQ",
+        "gateway.actions",
+        "gateway.actions.DLQ",
+        "Action.Field",
+        "Action.FieldDLQ",
+        "rm.feedback",
+        "rm.feedback.DLQ"
+    );
+
+      return queues.stream()
+          .map(a -> this.checkQueue(a))
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+}
 
 }


### PR DESCRIPTION
 rabbit health endpoint has been updated to check all queues used and return a list of the queues found, this has been changed so that it is consistent with the job service and allows for the smoke tests for both services to be consistent