### PR TITLE
initialise logger before event manager is used

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/rmadapter/Application.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/rmadapter/Application.java
@@ -35,24 +35,4 @@ public class Application {
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     return mapper;
   }
-
-  @Value("#{'${logging.profile}' == 'CLOUD'}")
-  private boolean useJsonLogging;
-
-  @PostConstruct
-  public void initJsonLogging() {
-    HashMap<Class<?>, Function<Object, String>> customMappers = new HashMap<>();
-    customMappers.put(LocalTime.class, Object::toString);
-    customMappers.put(LocalDateTime.class, Object::toString);
-
-    LoggingConfigs configs;
-
-    if (useJsonLogging) {
-      configs = LoggingConfigs.builder().customMapper(customMappers).build().useJson();
-    }
-    else {
-      configs = LoggingConfigs.builder().customMapper(customMappers).build();
-    }
-    LoggingConfigs.setCurrent(configs);
-  }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/rmadapter/config/GatewayEventsConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/rmadapter/config/GatewayEventsConfig.java
@@ -1,9 +1,17 @@
 package uk.gov.ons.census.fwmt.rmadapter.config;
 
+import com.godaddy.logging.LoggingConfigs;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
 import uk.gov.ons.census.fwmt.rmadapter.Application;
+
+import javax.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.function.Function;
 
 @Configuration
 public class GatewayEventsConfig {
@@ -30,5 +38,25 @@ public class GatewayEventsConfig {
         new String[] {INVALID_ACTION_INSTRUCTION, FAILED_TO_UNMARSHALL_ACTION_INSTRUCTION,
             FAILED_TO_MARSHALL_CANONICAL});
     return gatewayEventManager;
+  }
+
+  @Value("#{'${logging.profile}' == 'CLOUD'}")
+  private boolean useJsonLogging;
+
+  @PostConstruct
+  public void initJsonLogging() {
+    HashMap<Class<?>, Function<Object, String>> customMappers = new HashMap<>();
+    customMappers.put(LocalTime.class, Object::toString);
+    customMappers.put(LocalDateTime.class, Object::toString);
+
+    LoggingConfigs configs;
+
+    if (useJsonLogging) {
+      configs = LoggingConfigs.builder().customMapper(customMappers).build().useJson();
+    }
+    else {
+      configs = LoggingConfigs.builder().customMapper(customMappers).build();
+    }
+    LoggingConfigs.setCurrent(configs);
   }
 }


### PR DESCRIPTION
when the logger was being initialised in the main application the configuration was being ignored as the gateway event manager had already been initialised.